### PR TITLE
Refactor/benchmarks

### DIFF
--- a/benchmarks/memory_profiler.py
+++ b/benchmarks/memory_profiler.py
@@ -488,7 +488,4 @@ __all__ = [
     'GPUMemoryMonitor',
     'memory_profiler', 
     'MemoryBenchmark',
-    'profile_operation_memory',
-    'profile_model_memory',
-    'compare_memory_usage'
 ]

--- a/benchmarks/memory_profiler.py
+++ b/benchmarks/memory_profiler.py
@@ -1,5 +1,5 @@
 """
-메모리 사용량 프로파일링 도구
+메모리 사용량 프로파일링 도구 (리팩토링된 버전)
 """
 
 import torch
@@ -95,252 +95,249 @@ def memory_profiler(device: str = "cuda:0"):
         monitor.final_stats = stats
 
 
-def profile_operation_memory(
-    operation_func: Callable,
-    *args,
-    device: str = "cuda:0",
-    warmup_runs: int = 3,
-    profile_runs: int = 5,
-    **kwargs
-) -> Dict[str, Any]:
-    """
-    단일 연산의 메모리 사용량 프로파일링
-    
-    Args:
-        operation_func: 프로파일링할 함수
-        *args: 함수 인자들
-        device: 디바이스
-        warmup_runs: 워밍업 실행 횟수
-        profile_runs: 프로파일링 실행 횟수
-        **kwargs: 함수 키워드 인자들
-        
-    Returns:
-        메모리 사용량 통계
-    """
-    results = []
-    
-    # 워밍업
-    for _ in range(warmup_runs):
-        with torch.no_grad():
-            try:
-                _ = operation_func(*args, **kwargs)
-            except:
-                pass
-        torch.cuda.empty_cache()
-        gc.collect()
-    
-    # 실제 프로파일링
-    for run_idx in range(profile_runs):
-        with memory_profiler(device) as monitor:
-            try:
-                result = operation_func(*args, **kwargs)
-                # gradient 계산이 필요한 경우
-                if hasattr(result, 'backward') and result.requires_grad:
-                    dummy_loss = result.sum()
-                    dummy_loss.backward()
-            except Exception as e:
-                print(f"Error in run {run_idx}: {e}")
-                continue
-        
-        if hasattr(monitor, 'final_stats'):
-            results.append(monitor.final_stats)
-        
-        # 메모리 정리
-        torch.cuda.empty_cache()
-        gc.collect()
-    
-    if not results:
-        return {}
-    
-    # 평균 통계 계산
-    avg_stats = {}
-    for key in results[0].keys():
-        values = [r[key] for r in results if key in r]
-        if values:
-            avg_stats[f"avg_{key}"] = sum(values) / len(values)
-            avg_stats[f"max_{key}"] = max(values)
-            avg_stats[f"min_{key}"] = min(values)
-    
-    return avg_stats
-
-
-def profile_model_memory(
-    model: torch.nn.Module,
-    input_data: torch.Tensor,
-    targets: torch.Tensor = None,
-    device: str = "cuda:0",
-    include_backward: bool = True
-) -> Dict[str, float]:
-    """
-    모델 전체의 메모리 사용량 프로파일링
-    
-    Args:
-        model: 프로파일링할 모델
-        input_data: 입력 데이터
-        targets: 타겟 데이터 (loss 계산용)
-        device: 디바이스
-        include_backward: backward pass 포함 여부
-        
-    Returns:
-        메모리 사용량 통계
-    """
-    model.eval()
-    
-    def model_forward():
-        if targets is not None:
-            # 학습 모드로 설정
-            model.train()
-            output = model(input_data, targets)
-            return output
-        else:
-            # 추론 모드
-            with torch.no_grad():
-                output = model(input_data)
-            return output
-    
-    def model_forward_backward():
-        model.train()
-        if targets is not None:
-            loss = model(input_data, targets)
-            loss.backward()
-            return loss
-        else:
-            output = model(input_data)
-            # 더미 손실로 backward 수행
-            dummy_loss = output.sum()
-            dummy_loss.backward()
-            return dummy_loss
-    
-    # Forward pass 메모리 프로파일링
-    forward_stats = profile_operation_memory(
-        model_forward,
-        device=device,
-        warmup_runs=2,
-        profile_runs=3
-    )
-    
-    # Forward + Backward pass 메모리 프로파일링 (옵션)
-    if include_backward:
-        backward_stats = profile_operation_memory(
-            model_forward_backward,
-            device=device,
-            warmup_runs=2,
-            profile_runs=3
-        )
-        
-        # 결과 통합
-        combined_stats = {}
-        for key, value in forward_stats.items():
-            combined_stats[f"forward_{key}"] = value
-        for key, value in backward_stats.items():
-            combined_stats[f"backward_{key}"] = value
-        
-        return combined_stats
-    
-    return forward_stats
-
-
-def compare_memory_usage(
-    naive_func: Callable,
-    optimized_func: Callable,
-    *args,
-    device: str = "cuda:0",
-    **kwargs
-) -> Dict[str, Any]:
-    """
-    두 구현의 메모리 사용량 비교
-    
-    Args:
-        naive_func: 표준 구현 함수
-        optimized_func: 최적화 구현 함수
-        *args: 함수 인자들
-        device: 디바이스
-        **kwargs: 함수 키워드 인자들
-        
-    Returns:
-        비교 결과
-    """
-    print("Profiling naive implementation...")
-    naive_stats = profile_operation_memory(naive_func, *args, device=device, **kwargs)
-    
-    print("Profiling optimized implementation...")
-    optimized_stats = profile_operation_memory(optimized_func, *args, device=device, **kwargs)
-    
-    # 개선율 계산
-    comparison = {
-        "naive": naive_stats,
-        "optimized": optimized_stats,
-        "improvement": {}
-    }
-    
-    # 주요 메트릭들에 대한 개선율 계산
-    key_metrics = ["avg_peak_memory_gb", "avg_avg_memory_gb", "avg_memory_increase_gb"]
-    
-    for metric in key_metrics:
-        if metric in naive_stats and metric in optimized_stats:
-            naive_val = naive_stats[metric]
-            opt_val = optimized_stats[metric]
-            
-            if naive_val > 0:
-                improvement_pct = ((naive_val - opt_val) / naive_val) * 100
-                comparison["improvement"][metric] = improvement_pct
-    
-    return comparison
-
-
 class MemoryBenchmark:
-    """메모리 벤치마크 실행기"""
+    """메모리 벤치마크 실행기 (리팩토링된 버전)"""
     
     def __init__(self, device: str = "cuda:0"):
         self.device = device
         self.results = {}
     
-    def benchmark_operation(
+    def profile_operation_memory(
         self,
-        name: str,
-        naive_func: Callable,
-        optimized_func: Callable,
+        operation_func: Callable,
         *args,
+        warmup_runs: int = 3,
+        profile_runs: int = 5,
         **kwargs
-    ):
-        """단일 연산 벤치마크"""
-        print(f"\n=== Benchmarking {name} ===")
+    ) -> Dict[str, Any]:
+        """
+        단일 연산의 메모리 사용량 프로파일링
         
-        comparison = compare_memory_usage(
-            naive_func, optimized_func, *args, device=self.device, **kwargs
-        )
+        Args:
+            operation_func: 프로파일링할 함수
+            *args: 함수 인자들
+            warmup_runs: 워밍업 실행 횟수
+            profile_runs: 프로파일링 실행 횟수
+            **kwargs: 함수 키워드 인자들
+            
+        Returns:
+            메모리 사용량 통계
+        """
+        results = []
         
-        self.results[name] = comparison
+        # 워밍업
+        for _ in range(warmup_runs):
+            with torch.no_grad():
+                try:
+                    _ = operation_func(*args, **kwargs)
+                except:
+                    pass
+            torch.cuda.empty_cache()
+            gc.collect()
         
-        # 결과 출력
-        self._print_operation_results(name, comparison)
-    
-    def benchmark_model(
+        # 실제 프로파일링
+        for run_idx in range(profile_runs):
+            with memory_profiler(self.device) as monitor:
+                try:
+                    result = operation_func(*args, **kwargs)
+                    # gradient 계산이 필요한 경우
+                    if hasattr(result, 'backward') and result.requires_grad:
+                        dummy_loss = result.sum()
+                        dummy_loss.backward()
+                except Exception as e:
+                    print(f"Error in run {run_idx}: {e}")
+                    continue
+            
+            if hasattr(monitor, 'final_stats'):
+                results.append(monitor.final_stats)
+            
+            # 메모리 정리
+            torch.cuda.empty_cache()
+            gc.collect()
+        
+        if not results:
+            return {}
+        
+        # 평균 통계 계산
+        avg_stats = {}
+        for key in results[0].keys():
+            values = [r[key] for r in results if key in r]
+            if values:
+                avg_stats[f"avg_{key}"] = sum(values) / len(values)
+                avg_stats[f"max_{key}"] = max(values)
+                avg_stats[f"min_{key}"] = min(values)
+        
+        return avg_stats
+
+    def profile_model_memory(
         self,
-        name: str,
-        naive_model: torch.nn.Module,
-        optimized_model: torch.nn.Module,
+        model: torch.nn.Module,
         input_data: torch.Tensor,
-        targets: torch.Tensor = None
-    ):
-        """모델 전체 벤치마크"""
-        print(f"\n=== Benchmarking Model: {name} ===")
+        targets: torch.Tensor = None,
+        include_backward: bool = True,
+        warmup_runs: int = 2,
+        profile_runs: int = 3
+    ) -> Dict[str, float]:
+        """
+        모델 전체의 메모리 사용량 프로파일링
         
-        # 모델들을 디바이스로 이동
-        naive_model = naive_model.to(self.device)
-        optimized_model = optimized_model.to(self.device)
+        Args:
+            model: 프로파일링할 모델
+            input_data: 입력 데이터
+            targets: 타겟 데이터 (loss 계산용)
+            include_backward: backward pass 포함 여부
+            warmup_runs: 워밍업 실행 횟수
+            profile_runs: 프로파일링 실행 횟수
+            
+        Returns:
+            메모리 사용량 통계
+        """
+        # 모델과 데이터를 디바이스로 이동
+        model = model.to(self.device)
         input_data = input_data.to(self.device)
         if targets is not None:
             targets = targets.to(self.device)
         
+        model.eval()
+        
+        def model_forward():
+            if targets is not None:
+                # 학습 모드로 설정
+                model.train()
+                output = model(input_data, targets)
+                return output
+            else:
+                # 추론 모드
+                with torch.no_grad():
+                    output = model(input_data)
+                return output
+        
+        def model_forward_backward():
+            model.train()
+            if targets is not None:
+                loss = model(input_data, targets)
+                loss.backward()
+                return loss
+            else:
+                output = model(input_data)
+                # 더미 손실로 backward 수행
+                dummy_loss = output.sum()
+                dummy_loss.backward()
+                return dummy_loss
+        
+        # Forward pass 메모리 프로파일링
+        forward_stats = self.profile_operation_memory(
+            model_forward,
+            warmup_runs=warmup_runs,
+            profile_runs=profile_runs
+        )
+        
+        # Forward + Backward pass 메모리 프로파일링 (옵션)
+        if include_backward:
+            backward_stats = self.profile_operation_memory(
+                model_forward_backward,
+                warmup_runs=warmup_runs,
+                profile_runs=profile_runs
+            )
+            
+            # 결과 통합
+            combined_stats = {}
+            for key, value in forward_stats.items():
+                combined_stats[f"forward_{key}"] = value
+            for key, value in backward_stats.items():
+                combined_stats[f"backward_{key}"] = value
+            
+            return combined_stats
+        
+        return forward_stats
+
+    def compare_memory_usage(
+        self,
+        naive_func: Callable,
+        optimized_func: Callable,
+        *args,
+        warmup_runs: int = 3,
+        profile_runs: int = 5,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """
+        두 구현의 메모리 사용량 비교
+        
+        Args:
+            naive_func: 표준 구현 함수
+            optimized_func: 최적화 구현 함수
+            *args: 함수 인자들
+            warmup_runs: 워밍업 실행 횟수
+            profile_runs: 프로파일링 실행 횟수
+            **kwargs: 함수 키워드 인자들
+            
+        Returns:
+            비교 결과
+        """
+        print("Profiling naive implementation...")
+        naive_stats = self.profile_operation_memory(
+            naive_func, *args, warmup_runs=warmup_runs, profile_runs=profile_runs, **kwargs
+        )
+        
+        print("Profiling optimized implementation...")
+        optimized_stats = self.profile_operation_memory(
+            optimized_func, *args, warmup_runs=warmup_runs, profile_runs=profile_runs, **kwargs
+        )
+        
+        # 개선율 계산
+        comparison = {
+            "naive": naive_stats,
+            "optimized": optimized_stats,
+            "improvement": {}
+        }
+        
+        # 주요 메트릭들에 대한 개선율 계산
+        key_metrics = ["avg_peak_memory_gb", "avg_avg_memory_gb", "avg_memory_increase_gb"]
+        
+        for metric in key_metrics:
+            if metric in naive_stats and metric in optimized_stats:
+                naive_val = naive_stats[metric]
+                opt_val = optimized_stats[metric]
+                
+                if naive_val > 0:
+                    improvement_pct = ((naive_val - opt_val) / naive_val) * 100
+                    comparison["improvement"][metric] = improvement_pct
+        
+        return comparison
+
+    def compare_model_memory(
+        self,
+        naive_model: torch.nn.Module,
+        optimized_model: torch.nn.Module,
+        input_data: torch.Tensor,
+        targets: torch.Tensor = None,
+        include_backward: bool = True,
+        warmup_runs: int = 2,
+        profile_runs: int = 3
+    ) -> Dict[str, Any]:
+        """
+        두 모델의 메모리 사용량 비교
+        
+        Args:
+            naive_model: 표준 구현 모델
+            optimized_model: 최적화 구현 모델
+            input_data: 입력 데이터
+            targets: 타겟 데이터
+            include_backward: backward pass 포함 여부
+            warmup_runs: 워밍업 실행 횟수
+            profile_runs: 프로파일링 실행 횟수
+            
+        Returns:
+            비교 결과
+        """
         print("Profiling naive model...")
-        naive_stats = profile_model_memory(
-            naive_model, input_data, targets, self.device
+        naive_stats = self.profile_model_memory(
+            naive_model, input_data, targets, include_backward, warmup_runs, profile_runs
         )
         
         print("Profiling optimized model...")
-        optimized_stats = profile_model_memory(
-            optimized_model, input_data, targets, self.device
+        optimized_stats = self.profile_model_memory(
+            optimized_model, input_data, targets, include_backward, warmup_runs, profile_runs
         )
         
         # 비교 결과 저장
@@ -351,7 +348,8 @@ class MemoryBenchmark:
         }
         
         # 개선율 계산
-        for phase in ["forward", "backward"]:
+        phases = ["forward", "backward"] if include_backward else ["forward"]
+        for phase in phases:
             for metric_type in ["avg_peak_memory_gb", "avg_avg_memory_gb"]:
                 naive_key = f"{phase}_{metric_type}"
                 opt_key = f"{phase}_{metric_type}"
@@ -364,11 +362,8 @@ class MemoryBenchmark:
                         improvement_pct = ((naive_val - opt_val) / naive_val) * 100
                         comparison["improvement"][naive_key] = improvement_pct
         
-        self.results[f"model_{name}"] = comparison
-        
-        # 결과 출력
-        self._print_model_results(name, comparison)
-    
+        return comparison
+
     def _print_operation_results(self, name: str, comparison: Dict):
         """연산 결과 출력"""
         naive = comparison["naive"]
@@ -397,7 +392,7 @@ class MemoryBenchmark:
                     imp_pct = improvement[metric_key]
                     print(f"  Improvement: {imp_pct:.2f}%")
                 print()
-    
+
     def _print_model_results(self, name: str, comparison: Dict):
         """모델 결과 출력"""
         naive = comparison["naive"]
@@ -407,7 +402,13 @@ class MemoryBenchmark:
         print(f"\nModel Results for {name}:")
         print("-" * 50)
         
-        for phase in ["forward", "backward"]:
+        phases = []
+        if any(key.startswith("forward_") for key in naive.keys()):
+            phases.append("forward")
+        if any(key.startswith("backward_") for key in naive.keys()):
+            phases.append("backward")
+        
+        for phase in phases:
             print(f"\n{phase.capitalize()} Pass:")
             
             for metric_name, metric_suffix in [("Peak Memory", "peak_memory_gb"), ("Average Memory", "avg_memory_gb")]:
@@ -425,7 +426,7 @@ class MemoryBenchmark:
                     if naive_key in improvement:
                         imp_pct = improvement[naive_key]
                         print(f"    Improvement: {imp_pct:.2f}%")
-    
+
     def get_summary(self) -> Dict[str, Any]:
         """벤치마크 결과 요약 반환"""
         summary = {
@@ -458,12 +459,36 @@ class MemoryBenchmark:
         
         return summary
 
+    def clear_results(self):
+        """결과 초기화"""
+        self.results.clear()
+
+    def save_results(self, filepath: str):
+        """결과를 JSON 파일로 저장"""
+        import json
+        
+        def make_json_serializable(obj):
+            if isinstance(obj, dict):
+                return {k: make_json_serializable(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [make_json_serializable(item) for item in obj]
+            elif isinstance(obj, (int, float, str, bool, type(None))):
+                return obj
+            else:
+                return str(obj)
+        
+        serializable_results = make_json_serializable(self.results)
+        
+        with open(filepath, "w") as f:
+            json.dump(serializable_results, f, indent=2)
+        
+        print(f"Results saved to {filepath}")
 
 __all__ = [
     'GPUMemoryMonitor',
     'memory_profiler', 
+    'MemoryBenchmark',
     'profile_operation_memory',
     'profile_model_memory',
-    'compare_memory_usage',
-    'MemoryBenchmark'
+    'compare_memory_usage'
 ]

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -30,4 +30,11 @@ __all__ = [
     'OptimizedLinearCrossEntropy', 
     'CustomFusedLinearCrossEntropyFunction',
     'create_linear_cross_entropy'
+
+	# Layer Normalization
+    'NaiveLayerNorm',
+    'OptimizedLayerNorm',
+    'LigerLayerNormFunction',
+    'create_layer_norm',
+    'layer_norm'
 ]

--- a/ops/layer_norm.py
+++ b/ops/layer_norm.py
@@ -1,0 +1,414 @@
+"""
+Layer Normalization 연산 구현
+- NaiveLayerNorm: 표준 PyTorch 구현
+- OptimizedLayerNorm: Triton 최적화 구현
+"""
+
+import math
+import operator
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+from ops.utils import calculate_settings, ensure_contiguous
+
+# Triton 버전별 rsqrt import 처리
+def _import_rsqrt():
+    """Triton 버전에 따른 rsqrt 함수 import"""
+    try:
+        import importlib.metadata
+        triton_version = importlib.metadata.version("triton")
+        from packaging import version as pkg_version
+        
+        if pkg_version.parse(triton_version) >= pkg_version.parse("3.0.0"):
+            try:
+                from triton.language.extra.libdevice import rsqrt
+            except ModuleNotFoundError:
+                try:
+                    from triton.language.extra.cuda.libdevice import rsqrt
+                except ModuleNotFoundError:
+                    from triton.language.math import rsqrt
+        else:
+            from triton.language.math import rsqrt
+        return rsqrt
+    except:
+        # 기본값으로 math 모듈에서 import
+        from triton.language.math import rsqrt
+        return rsqrt
+
+rsqrt = _import_rsqrt()
+
+# ========================================
+# Triton 커널 구현
+# ========================================
+
+@triton.jit
+def _layer_norm_forward_kernel(
+    Y_ptr,  # pointer to output, shape (n_rows, n_cols)
+    Y_row_stride,  # stride of each row in output
+    X_ptr,  # pointer to input, shape (n_rows, n_cols)
+    X_row_stride,  # stride of each row in input
+    W_ptr,  # pointer to weights, shape (n_cols,)
+    W_row_stride,  # stride of each row in weights
+    B_ptr,  # pointer to bias, shape (n_cols,)
+    B_row_stride,  # stride of each row in bias
+    Mean_ptr,  # pointer to mean, shape (n_rows,)
+    Mean_row_stride,  # stride of each row in mean
+    RSTD_ptr,  # pointer to rstd, shape (n_rows,)
+    RSTD_row_stride,  # stride of each row in rstd
+    n_cols,
+    eps,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Layer normalization forward kernel.
+    References:
+    https://arxiv.org/abs/1607.06450
+    https://github.com/karpathy/llm.c/blob/master/doc/layernorm/layernorm.md
+    """
+    row_idx = tl.program_id(0)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < n_cols
+
+    Y_ptr += row_idx * Y_row_stride
+    X_ptr += row_idx * X_row_stride
+    Mean_ptr += row_idx * Mean_row_stride
+    RSTD_ptr += row_idx * RSTD_row_stride
+
+    X_row = tl.load(X_ptr + col_offsets, mask=mask, other=0)
+    W_row = tl.load(W_ptr + col_offsets, mask=mask, other=0)
+    B_row = tl.load(B_ptr + col_offsets, mask=mask, other=0)
+
+    mean = tl.sum(X_row, axis=0) / n_cols
+    Xmm = tl.where(mask, X_row - mean, 0)
+    var = tl.sum(Xmm * Xmm, axis=0) / n_cols
+    rstd = rsqrt(var + eps)
+
+    tl.store(Mean_ptr, mean)
+    tl.store(RSTD_ptr, rstd)
+
+    Y_row = Xmm * rstd * W_row + B_row
+
+    tl.store(Y_ptr + col_offsets, Y_row, mask=mask)
+
+
+@triton.jit
+def _layer_norm_backward_kernel(
+    X_ptr,  # pointer to input, shape (n_rows, n_cols)
+    W_ptr,  # pointer to weights, shape (n_cols,)
+    Mean_ptr,  # pointer to mean, shape (n_rows,)
+    RSTD_ptr,  # pointer to rstd, shape (n_rows,)
+    DX_ptr,  # pointer to input grad, shape (n_rows, n_cols)
+    DW_ptr,  # pointer to weights grad, shape (n_cols,)
+    DB_ptr,  # pointer to bias grad, shape (n_cols,)
+    DY_ptr,  # pointer to output grad, shape (n_rows, n_cols)
+    stride_x,  # stride of each row in input
+    stride_dx,  # stride of each row in input grad
+    stride_dw,  # stride of each row in weights grad
+    stride_db,  # stride of each row in bias grad
+    stride_dy,  # stride of each row in output grad
+    n_rows,
+    n_cols,
+    rows_per_program: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    dtype: tl.constexpr,
+):
+    """
+    Layer normalization backward kernel.
+    References:
+    https://arxiv.org/abs/1607.06450
+    https://github.com/karpathy/llm.c/blob/master/doc/layernorm/layernorm.md
+    https://triton-lang.org/main/getting-started/tutorials/05-layer-norm.html
+    https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/ops/triton/layer_norm.py
+    """
+    row_block_id = tl.program_id(0)
+    row_start = row_block_id * rows_per_program
+    row_end = min((row_block_id + 1) * rows_per_program, n_rows)
+    cols = tl.arange(0, BLOCK_SIZE)
+    mask = cols < n_cols
+
+    dw_row = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    db_row = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+
+    X_ptr += row_start * stride_x
+    Mean_ptr += row_start
+    RSTD_ptr += row_start
+    DX_ptr += row_start * stride_dx
+    DY_ptr += row_start * stride_dy
+
+    for _ in range(row_start, row_end):
+        x = tl.load(X_ptr + cols, mask=mask, other=0.0)
+        w = tl.load(W_ptr + cols, mask=mask, other=0.0)
+        dy = tl.load(DY_ptr + cols, mask=mask, other=0.0)
+        mean = tl.load(Mean_ptr)
+        rstd = tl.load(RSTD_ptr)
+
+        x_hat = (x - mean) * rstd
+        wdy = w * dy
+        c1 = tl.sum(x_hat * wdy, axis=0) / n_cols
+        c2 = tl.sum(wdy, axis=0) / n_cols
+        dx = (wdy - (x_hat * c1 + c2)) * rstd
+        tl.store(DX_ptr + cols, dx.to(dtype), mask=mask)
+
+        dw_row += dy * x_hat
+        db_row += dy
+
+        X_ptr += stride_x
+        Mean_ptr += 1
+        RSTD_ptr += 1
+        DX_ptr += stride_dx
+        DY_ptr += stride_dy
+
+    tl.store(DW_ptr + row_block_id * stride_dw + cols, dw_row.to(dtype), mask=mask)
+    tl.store(DB_ptr + row_block_id * stride_db + cols, db_row.to(dtype), mask=mask)
+
+
+# ========================================
+# Python 래퍼 함수들
+# ========================================
+
+def layer_norm_forward(X, W, B, eps):
+    """Layer normalization forward pass"""
+    shape = X.shape
+    dim = shape[-1]
+    X = X.view(-1, dim)
+    n_rows, n_cols = X.shape
+    BLOCK_SIZE, num_warps = calculate_settings(n_cols)
+    Y = torch.empty((n_rows, n_cols), dtype=X.dtype, device=X.device)
+    Mean = torch.empty(n_rows, dtype=X.dtype, device=X.device)
+    RSTD = torch.empty(n_rows, dtype=X.dtype, device=X.device)
+    
+    if X.shape[1] != W.shape[0]:
+        raise ValueError(
+            f"Incompatible dimensions: input feature size (X.shape[1]={X.shape[1]}) "
+            f"must match weight size (W.shape[0]={W.shape[0]})"
+        )
+
+    # Device-specific optimization
+    kernel_args = {}
+    if X.device.type == "xpu":
+        kernel_args["grf_mode"] = "large"
+
+    _layer_norm_forward_kernel[(n_rows,)](
+        Y,
+        Y.stride(0),
+        X,
+        X.stride(0),
+        W,
+        W.stride(0),
+        B,
+        B.stride(0),
+        Mean,
+        Mean.stride(0),
+        RSTD,
+        RSTD.stride(0),
+        n_cols,
+        eps,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=num_warps,
+        **kernel_args,
+    )
+    return Y.view(*shape), X, Mean, RSTD, BLOCK_SIZE, num_warps
+
+
+def layer_norm_backward(dY, X, W, B, Mean, RSTD):
+    """Layer normalization backward pass"""
+    shape = dY.shape
+    dim = shape[-1]
+    dY = dY.view(-1, dim)
+    n_rows, n_cols = dY.shape
+
+    # Get device-specific multiprocessor count
+    sm_count = 1
+    if X.device.type == "cuda":
+        sm_count = torch.cuda.get_device_properties(X.device).multi_processor_count
+    elif X.device.type == "xpu":
+        sm_count = torch.xpu.get_device_properties(X.device).gpu_eu_count
+
+    DX = torch.empty((n_rows, n_cols), dtype=X.dtype, device=X.device)
+    _DW = torch.empty((sm_count, n_cols), dtype=W.dtype, device=W.device)
+    _DB = torch.empty((sm_count, n_cols), dtype=W.dtype, device=W.device)
+
+    BLOCK_SIZE, num_warps = calculate_settings(n_cols)
+    if n_cols > BLOCK_SIZE:
+        raise RuntimeError(
+            f"Feature dimension {n_cols} exceeds maximum supported size of {BLOCK_SIZE}. "
+            f"Consider using a smaller feature dimension."
+        )
+
+    rows_per_program = math.ceil(n_rows / sm_count)
+    grid = (sm_count,)
+    
+    # Map PyTorch dtype to Triton dtype
+    triton_dtype = (
+        tl.float32 if X.dtype == torch.float32
+        else tl.bfloat16 if X.dtype == torch.bfloat16
+        else tl.float16 if X.dtype == torch.float16
+        else tl.float32  # fallback to float32 for other types
+    )
+
+    # Device-specific optimization
+    kernel_args = {}
+    if X.device.type == "xpu":
+        kernel_args.update({"grf_mode": "large", "num_warps": 32, "num_stages": 4})
+
+    _layer_norm_backward_kernel[grid](
+        X,
+        W,
+        Mean,
+        RSTD,
+        DX,
+        _DW,
+        _DB,
+        dY,
+        X.stride(0),
+        DX.stride(0),
+        _DW.stride(0),
+        _DB.stride(0),
+        dY.stride(0),
+        n_rows,
+        n_cols,
+        rows_per_program,
+        BLOCK_SIZE=BLOCK_SIZE,
+        dtype=triton_dtype,
+        **kernel_args,
+    )
+
+    DW = _DW.sum(dim=0).to(W.dtype)
+    DB = _DB.sum(dim=0).to(W.dtype)
+
+    DX = DX.view(*shape)
+    return DX, DW, DB
+
+
+# ========================================
+# PyTorch Function 클래스
+# ========================================
+
+class LigerLayerNormFunction(torch.autograd.Function):
+    """Liger Kernel Layer Normalization Function"""
+    
+    @staticmethod
+    @ensure_contiguous
+    def forward(ctx, X, W, B, eps):
+        Y, X, Mean, RSTD, BLOCK_SIZE, num_warps = layer_norm_forward(X, W, B, eps)
+        ctx.save_for_backward(X, W, B, Mean, RSTD)
+        return Y
+
+    @staticmethod
+    @ensure_contiguous
+    def backward(ctx, dY):
+        X, W, B, Mean, RSTD = ctx.saved_tensors
+        DX, DW, DB = layer_norm_backward(dY, X, W, B, Mean, RSTD)
+        return DX, DW, DB, None
+
+
+# ========================================
+# 모듈 클래스들
+# ========================================
+
+class NaiveLayerNorm(nn.Module):
+    """표준 PyTorch Layer Normalization 구현"""
+    
+    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True, device=None, dtype=None):
+        super().__init__()
+        factory_kwargs = {'device': device, 'dtype': dtype}
+        self.normalized_shape = normalized_shape
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
+        
+        if self.elementwise_affine:
+            self.weight = nn.Parameter(torch.empty(normalized_shape, **factory_kwargs))
+            self.bias = nn.Parameter(torch.empty(normalized_shape, **factory_kwargs))
+        else:
+            self.register_parameter('weight', None)
+            self.register_parameter('bias', None)
+            
+        self.reset_parameters()
+    
+    def reset_parameters(self):
+        """Initialize parameters."""
+        if self.elementwise_affine:
+            nn.init.ones_(self.weight)
+            nn.init.zeros_(self.bias)
+    
+    def forward(self, input):
+        """Forward pass using PyTorch's implementation"""
+        return F.layer_norm(input, (self.normalized_shape,), self.weight, self.bias, self.eps)
+    
+    def extra_repr(self):
+        return f'{self.normalized_shape}, eps={self.eps}, elementwise_affine={self.elementwise_affine}'
+
+
+class OptimizedLayerNorm(nn.Module):
+    """Triton 최적화된 Layer Normalization 구현"""
+    
+    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True, device=None, dtype=None):
+        super().__init__()
+        factory_kwargs = {'device': device, 'dtype': dtype}
+        self.normalized_shape = normalized_shape
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
+        
+        if self.elementwise_affine:
+            self.weight = nn.Parameter(torch.empty(normalized_shape, **factory_kwargs))
+            self.bias = nn.Parameter(torch.empty(normalized_shape, **factory_kwargs))
+        else:
+            self.register_parameter('weight', None)
+            self.register_parameter('bias', None)
+            
+        self.reset_parameters()
+    
+    def reset_parameters(self):
+        """Initialize parameters."""
+        if self.elementwise_affine:
+            nn.init.ones_(self.weight)
+            nn.init.zeros_(self.bias)
+    
+    def forward(self, input):
+        """Forward pass using Triton optimized implementation"""
+        if self.elementwise_affine:
+            return LigerLayerNormFunction.apply(input, self.weight, self.bias, self.eps)
+        else:
+            # Fallback to PyTorch's implementation when no learnable parameters
+            return F.layer_norm(input, (self.normalized_shape,), None, None, self.eps)
+    
+    def extra_repr(self):
+        return f'{self.normalized_shape}, eps={self.eps}, elementwise_affine={self.elementwise_affine}'
+
+
+def create_layer_norm(normalized_shape, eps=1e-5, elementwise_affine=True, 
+                     use_optimized=False, device=None, dtype=None):
+    """Layer Normalization 생성 팩토리 함수"""
+    if use_optimized:
+        return OptimizedLayerNorm(normalized_shape, eps, elementwise_affine, device, dtype)
+    else:
+        return NaiveLayerNorm(normalized_shape, eps, elementwise_affine, device, dtype)
+
+
+# 함수형 인터페이스
+def layer_norm(input, weight, bias, eps=1e-5):
+    """
+    Functional interface for layer normalization using Triton optimization.
+    
+    Args:
+        input: Input tensor
+        weight: Weight tensor
+        bias: Bias tensor  
+        eps: Small value for numerical stability
+        
+    Returns:
+        Normalized tensor
+    """
+    return LigerLayerNormFunction.apply(input, weight, bias, eps)
+
+
+__all__ = [
+    'NaiveLayerNorm',
+    'OptimizedLayerNorm',
+    'LigerLayerNormFunction',
+    'create_layer_norm',
+    'layer_norm'
+]


### PR DESCRIPTION
# 주요 변경사항
## 1. SpeedBenchmark 클래스의 메서드로 통합

profile_operation_speed(): 단일 연산 속도 프로파일링
profile_model_speed(): 모델 속도 프로파일링
compare_speed(): 두 연산의 속도 비교
compare_model_speed(): 두 모델의 속도 비교

## 2. MemoryBenchmark 클래스의 메서드로 통합

profile_operation_memory(): 단일 연산 메모리 프로파일링
profile_model_memory(): 모델 메모리 프로파일링
compare_memory_usage(): 두 연산의 메모리 사용량 비교
compare_model_memory(): 두 모델의 메모리 사용량 비교

## 3. 새로운 사용 방법
단일 연산 프로파일링

```
benchmark = SpeedBenchmark("cuda:0")

# 단일 연산 메모리 프로파일링
def my_operation():
    return torch.randn(1000, 1000).cuda()

stats = benchmark.profile_operation_memory(
    my_operation,
    warmup_runs=5,
    profile_runs=10
)

# 단일 연산 속도 프로파일링
def my_operation():
    return torch.matmul(torch.randn(1000, 1000).cuda(), torch.randn(1000, 1000).cuda())

stats = benchmark.profile_operation_speed(
    my_operation,
    warmup_runs=10,
    profile_runs=100
)
두 연산 비교
python# 두 구현 비교
comparison = benchmark.compare_[speed or memory](
    naive_func,
    optimized_func, 
    input_tensor,
    warmup_runs=10,
    profile_runs=100
)
```
모델 프로파일링
````
python# 단일 모델 프로파일링
model_stats = benchmark.profile_model_[speed or memory](
    model,
    input_data,
    targets=None,
    warmup_runs=5,
    profile_runs=50,
    include_backward=True
)

# 두 모델 비교
model_comparison = benchmark.compare_model_[speed or memory](
    naive_model,
    optimized_model,
    input_data,
    targets=None,
    warmup_runs=5,
    profile_runs=50,
    include_backward=True
)
````